### PR TITLE
get deletion requests & approve

### DIFF
--- a/backend/routes/DeletionRequestsRoutes.js
+++ b/backend/routes/DeletionRequestsRoutes.js
@@ -1,7 +1,9 @@
 const express = require("express");
 const router = express.Router();
-const { requestAccountDeletion } = require("../controllers/AccountDeletionRequestController");
+const { requestAccountDeletion, getDeletionRequests, approveDeletionRequest } = require("../controllers/AccountDeletionRequestController");
 
 router.post("/request-deletion/:role/:userId", requestAccountDeletion);
-
+router.get("/deletion-requests", getDeletionRequests);
+router.delete("/deletion-request/approve/:requestId", approveDeletionRequest);
+  
 module.exports = router;

--- a/frontend/src/api/AdminService.js
+++ b/frontend/src/api/AdminService.js
@@ -26,7 +26,6 @@ export async function changeAdminPassword(id, oldPassword, newPassword) {
 }
 export const deleteUser = async (id) => {
   try {
-    // Use backticks for template literals
     const response = await axios.delete(`/admin/user/${id}`);
     return response.data;
   } catch (error) {
@@ -67,3 +66,27 @@ export const createGovernor = async (name, password) => {
     throw new Error(errorMessage);
   }
 }
+
+export const getPendingDeletionRequests = async () => {
+  try {
+    const response = await axios.get("/deletion-requests"); 
+    console.log(response.data);
+    return response.data;  
+  } catch (error) {
+    console.error("Error fetching pending deletion requests:", error);
+    throw error;
+  }
+};
+
+export const approveDeletionRequest = async (requestId) => {
+  console.log(requestId, "in the service")
+  try {
+    const response = await axios.delete(`/deletion-request/approve/${requestId}`); 
+    return response.data; 
+  } catch (error) {
+    console.error(`Error approving deletion request with ID ${requestId}:`, error);
+    throw error;
+  }
+};
+
+

--- a/frontend/src/components/navbar/AdminNavBar.js
+++ b/frontend/src/components/navbar/AdminNavBar.js
@@ -27,6 +27,9 @@ const AdminNavBar = () => {
           <Link to="/admin/delete-user">Delete User</Link>
         </div>
         <div class="nav-bar-link">
+          <Link to="/deletion-requests">Deletion Requests</Link>
+        </div>
+        <div class="nav-bar-link">
           <Link to="/admin/complaints">View Complaints</Link>
         </div>
         <div class="nav-bar-link">

--- a/frontend/src/components/requests/DeletionRequestsList.js
+++ b/frontend/src/components/requests/DeletionRequestsList.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import { getPendingDeletionRequests, approveDeletionRequest } from "../../api/AdminService";  
+
+const DeletionRequestsList = () => {
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchRequests = async () => {
+      try {
+        const data = await getPendingDeletionRequests();
+        setRequests(data.deletionRequests);  
+      } catch (err) {
+        setError("Failed to fetch deletion requests.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchRequests();
+  }, []);
+
+  const handleApprove = async (requestId) => {
+    console.log(requestId)
+    try {
+      const result = await approveDeletionRequest(requestId);   
+      alert(result.message);  
+      setRequests((prevRequests) => prevRequests.filter((req) => req._id !== requestId)); 
+    } catch (err) {
+        console.error("Error in approving deletion request:", err);  
+        alert("Failed to approve request.");
+    }
+  };
+
+  if (loading) {
+    return <p>Loading deletion requests...</p>;
+  }
+
+  if (error) {
+    return <p>{error}</p>;
+  }
+
+  return (
+    <div>
+      <ul className="user-list">
+        {requests.map((request) => (
+          <li key={request._id} className="user-list-item">
+            <div className="user-details">
+                <span><strong>User: </strong>{request.user}</span>
+                <span><strong>Role: </strong>{request.role}</span>
+            </div>
+            <button className="delete-button" onClick={() => handleApprove(request._id)}>Approve</button>
+            <hr />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DeletionRequestsList;

--- a/frontend/src/pages/admin/AdminViewUsers.js
+++ b/frontend/src/pages/admin/AdminViewUsers.js
@@ -57,7 +57,6 @@ const UserList = () => {
                 <span><strong>Type:</strong> {user.role}</span>
               </div>
               <button className="delete-button" onClick={() => deleteUsers(user.userId)}>Delete</button>
-
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/admin/DeletionRequests.js
+++ b/frontend/src/pages/admin/DeletionRequests.js
@@ -1,0 +1,15 @@
+import React from "react";
+import DeletionRequestsList from "../../components/requests/DeletionRequestsList";  
+import AdminNavBar from "../../components/navbar/AdminNavBar"
+
+const DeletionRequests = () => {
+  return (
+    <div>
+        <AdminNavBar />
+        <h2 className="user-list-title">Pending Deletion Requests</h2>
+        <DeletionRequestsList />
+    </div>
+  );
+};
+
+export default DeletionRequests;

--- a/frontend/src/routes/AdminRoutes.js
+++ b/frontend/src/routes/AdminRoutes.js
@@ -9,6 +9,8 @@ import CreateNewAdmin from "../pages/admin/CreateNewAdmin";
 import ComplaintsPage from "../pages/admin/Complaints";
 import AdminChangePassword from "../pages/admin/AdminProfile";
 import Requests from "../pages/admin/Requests";
+import DeletionRequests from "../pages/admin/DeletionRequests";
+
 const adminRoutes = [
   { path: "/admin", element: <AdminDashboard /> },
   { path: "/activity-categories", element: <ActivityCategoryDetails /> },
@@ -21,7 +23,7 @@ const adminRoutes = [
   { path: "/admin/complaints", element: <ComplaintsPage /> },
   { path: "/admin/changepassword", element: <AdminChangePassword /> },
   { path: "/admin/requests", element: <Requests /> },
-
+  { path: "/deletion-requests", element: <DeletionRequests />}
 
 
 


### PR DESCRIPTION
an admin can fetch all the deletion requests in a separate page (until we know whether requests should appear for the admin to delete or the admin will be able to delete any account while also approving requests)
- an admin can view deletion requests
- an admin can approve the requests 
but i cant test the approval since also because of the userids in the db